### PR TITLE
Fixed gitlab wiki page creation

### DIFF
--- a/src/proxy/gitlab/diazo.xml
+++ b/src/proxy/gitlab/diazo.xml
@@ -7,6 +7,10 @@
     <before css:theme-children="#main-content" css:content-children="body" />
 
     <merge attributes="class" css:theme="body" css:content="body" />
+    
+    <!-- Add gitlab properties -->
+    <merge attributes="data-page" css:theme="body" css:content="body" />
+    <merge attributes="data-project-id" css:theme="body" css:content="body" />
 
     <drop css:content="#top-panel" />
     <drop css:content=".navbar-gitlab" />

--- a/src/proxy/gitlab/templates/proxy/gitlab.html
+++ b/src/proxy/gitlab/templates/proxy/gitlab.html
@@ -3,6 +3,14 @@
 
 {% block head_css %}
 <style>
+  /* Reset left and with for .modal-dialog style (like gitlab does), 
+     the bootstrap.css one makes it small */
+  @media screen and (min-width: 768px) {
+    .modal-dialog {
+      left: auto;
+      width: auto;
+    }
+  }
   div#main-content {
     margin-top: 65px;
   }


### PR DESCRIPTION
Gitlab needs two non-standard HTML body attributes to work properly: data-page and data-project-id.
Since the whole JS is loaded at once, Gitlab uses 'data-page' for determining what the current page is in order do load proper JS for that page. 

The main JS dispatcher for Gitlab can be checked out here:
https://github.com/colab-community/gitlabhq/blob/master/app/assets/javascripts/dispatcher.js.coffee

The wiki button didn't work because the expression '$('body').attr('data-page')' returned 'undefined',  not loading any of the cases from that switch-case.
