### PR TITLE
Fixed virtualenvwrapper installation when using trusty64

### DIFF
--- a/vagrant/ubuntu.sh
+++ b/vagrant/ubuntu.sh
@@ -5,7 +5,9 @@ set -ex
 ### Install dependencies
 apt-get update
 
-apt-get install curl git unzip mercurial build-essential libev-dev gettext libxml2-dev libxslt1-dev libssl-dev libffi-dev libjpeg-dev zlib1g-dev libfreetype6-dev libpq-dev python-dev postgresql virtualenvwrapper python-pip -y
+-apt-get install curl git unzip mercurial build-essential libev-dev gettext libxml2-dev libxslt1-dev libssl-dev libffi-dev libjpeg-dev zlib1g-dev libfreetype6-dev libpq-dev python-dev postgresql python-pip -y
+
+pip install virtualenvwrapper
 
 
 ### Create conf directory


### PR DESCRIPTION
virtualenvwrapper.sh script is located in
/etc/bash_completion.d/virtualenvwrapper when installed via apt-get