### PR TITLE
Plugin extra configurations

### DIFF
--- a/colab/utils/conf.py
+++ b/colab/utils/conf.py
@@ -127,7 +127,7 @@ def load_colab_apps():
 
         fields = ['verbose_name', 'upstream', 'urls',
                   'menu_urls', 'middlewares', 'dependencies',
-                  'context_processors', 'private_token', 'name']
+                  'context_processors', 'private_token', 'name', 'extra']
 
         for key in fields:
             value = py_settings_d.get(key)


### PR DESCRIPTION
Added configuration field for plugin extra configurations that do not affect colab

Would be nice that `private_token` gets deprecated and that the plugins to use it through the `extra`.

Signed off by: Diego Araújo <diegoamc90@gmail.com>