### PR TITLE
Make UserChangeForm and UserCreationForm regex equal

### DIFF
--- a/colab/accounts/forms.py
+++ b/colab/accounts/forms.py
@@ -170,6 +170,7 @@ class UserCreationForm(UserForm):
                                 error_messages={
                                     'invalid': _(("This value may contain only"
                                                   " letters and numbers."))})
+
     password1 = forms.CharField(label=_("Password"),
                                 widget=forms.PasswordInput)
     password2 = forms.CharField(label=_("Password confirmation"),
@@ -233,7 +234,7 @@ class UserCreationForm(UserForm):
 
 class UserChangeForm(forms.ModelForm):
     username = forms.RegexField(
-        label=_("Username"), max_length=30, regex=r"^[\w*]",
+        label=_("Username"), max_length=30, regex=r'^[\w.@+-]+$',
         help_text=_("Required. 30 characters or fewer. Letters and digits."),
         error_messages={
             'invalid': _("This value may contain only letters and numbers.")})

--- a/colab/accounts/models.py
+++ b/colab/accounts/models.py
@@ -4,7 +4,6 @@ import urlparse
 
 from django.db import models
 from django.contrib.auth.models import AbstractUser, UserManager
-from django.core import validators
 from django.core.urlresolvers import reverse
 from django.utils.crypto import get_random_string
 from django.utils.translation import ugettext_lazy as _
@@ -76,9 +75,4 @@ class User(AbstractUser):
 User._meta.get_field('email')._unique = True
 User._meta.get_field('username').help_text = _(
     u'Required. 30 characters or fewer. Letters and digits.'
-)
-User._meta.get_field('username').validators[0] = validators.RegexValidator(
-    r'^\w+$',
-    _('Enter a valid username.'),
-    'invalid'
 )

--- a/colab/accounts/tests/test_forms.py
+++ b/colab/accounts/tests/test_forms.py
@@ -3,10 +3,12 @@ Test Form class.
 Objective: Test parameters, and behavior.
 """
 
+import datetime
+
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 
-from colab.accounts.forms import UserCreationForm
+from colab.accounts.forms import UserCreationForm, UserChangeForm
 from colab.accounts.models import User
 
 
@@ -34,6 +36,19 @@ class FormTest(TestCase):
         form = UserCreationForm(data=form_data)
         return form
 
+    def create_change_form_data(self, username):
+        updated_data = {'username': username,
+                        'email': 'email@email.com',
+                        'last_login': datetime.date.today(),
+                        'date_joined': datetime.date.today()}
+        initial = {'email': 'email@email.com',
+                   'first_name': 'colabName',
+                   'last_name': 'secondName',
+                   'username': 'colab',
+                   'password': '123colab4'}
+        form = UserChangeForm(initial=initial, data=updated_data)
+        return form
+
     def test_already_registered_email(self):
         form = self.create_form_data('usertest@colab.com.br',
                                      'colab')
@@ -55,6 +70,14 @@ class FormTest(TestCase):
     def test_not_valid_username(self):
         form = self.create_form_data('user@email.com',
                                      'colab!')
+        self.assertFalse(form.is_valid())
+
+    def test_update_valid_username(self):
+        form = self.create_change_form_data('colab123@colab-spb.com')
+        self.assertTrue(form.is_valid())
+
+    def test_update_not_valid_username(self):
+        form = self.create_change_form_data('colab!')
         self.assertFalse(form.is_valid())
 
     def tearDown(self):

--- a/colab/accounts/tests/test_forms.py
+++ b/colab/accounts/tests/test_forms.py
@@ -24,26 +24,38 @@ class FormTest(TestCase):
         user.last_name = "COLAB"
         user.save()
 
-    def create_form_data(self):
-        form_data = {'email': 'usertest@colab.com.br',
+    def create_form_data(self, email, username):
+        form_data = {'email': email,
                      'first_name': 'colabName',
                      'last_name': 'secondName',
-                     'username': 'colab',
+                     'username': username,
                      'password1': '123colab4',
                      'password2': '123colab4'}
         form = UserCreationForm(data=form_data)
         return form
 
     def test_already_registered_email(self):
-        form = self.create_form_data()
+        form = self.create_form_data('usertest@colab.com.br',
+                                     'colab')
         self.assertFalse(form.is_valid())
 
     def test_registered_email_message(self):
-        form = self.create_form_data()
+        form = self.create_form_data('usertest@colab.com.br',
+                                     'colab')
         msg = form.error_messages.get('duplicate_email') % {
             'url': reverse('login')
         }
         self.assertIn(msg, str(form))
+
+    def test_valid_username(self):
+        form = self.create_form_data('user@email.com',
+                                     'colab123@colab-spb.com')
+        self.assertTrue(form.is_valid())
+
+    def test_not_valid_username(self):
+        form = self.create_form_data('user@email.com',
+                                     'colab!')
+        self.assertFalse(form.is_valid())
 
     def tearDown(self):
         pass


### PR DESCRIPTION
In account form, the regex from UserChangeForm and UserCreationForm were different. This pull request is fixing that.