### PR TITLE
Change user-scalable in viewport meta tag

### DIFF
--- a/colab/templates/base.html
+++ b/colab/templates/base.html
@@ -6,7 +6,7 @@
   <head>
   {% block head %}
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=yes" />
     {% block metarobots %}
       {% if ROBOTS_NOINDEX %}
         <meta name="robots" content="noindex, nofollow" />


### PR DESCRIPTION
Now, mobile users can use yours fingers to zoom in and zoom out

Signed-off-by: Matheus Fernandes <matheus.souza.fernandes@gmail.com>