### PR TITLE
Filtering invalid lastest collaborations results

### DIFF
--- a/colab/home/views.py
+++ b/colab/home/views.py
@@ -39,6 +39,9 @@ def dashboard(request):
         highest_score_threads, lists_for_user, lambda t: t.latest_message)
 
     latest_results, count_types = get_collaboration_data(user)
+
+    latest_results = filter(lambda elem: elem.modified is not None,
+                            latest_results)
     latest_results.sort(key=lambda elem: elem.modified, reverse=True)
 
     context = {


### PR DESCRIPTION
Fix the date comparison with None type bug. I don't know if this is the better way to fix it, we need to discuss a better filter and a better data definition for this kind of data, the latest collaborations/collaborations in general.