### PR TITLE
Fix dashboard widgets not appearing

### DIFF
--- a/colab/super_archives/templates/widgets/dashboard_collaboration_graph.html
+++ b/colab/super_archives/templates/widgets/dashboard_collaboration_graph.html
@@ -1,14 +1,12 @@
 {% load i18n %}
-<html>
-  <head>
-    {% trans "Contributions" as collabs_name %}
-    {% include "doughnut-chart.html" with chart_data=type_count chart_canvas="collabs" name=collabs_name %}
-  </head>
-  <body>
-    <h3 class="column-align">{% trans "Collaboration Graph" %}</h3>
-    <div class="chart collabs">
-        <canvas width="270" height="270"></canvas>
-      <p></p>
-    </div>
-  </body>
-</html>
+<head>
+  {% trans "Contributions" as collabs_name %}
+  {% include "doughnut-chart.html" with chart_data=type_count chart_canvas="collabs" name=collabs_name %}
+</head>
+<body>
+  <h3 class="column-align">{% trans "Collaboration Graph" %}</h3>
+  <div class="chart collabs">
+      <canvas width="270" height="270"></canvas>
+    <p></p>
+  </div>
+</body>

--- a/colab/super_archives/templates/widgets/dashboard_latest_collaborations.html
+++ b/colab/super_archives/templates/widgets/dashboard_latest_collaborations.html
@@ -1,6 +1,9 @@
 {% load i18n %}
 
-<div class="col-lg-6 col-md-6">
+<head>
+</head>
+
+<body>
   <h3 class="column-align">
     {% trans "Latest Collaborations" %}
   </h3>
@@ -18,4 +21,4 @@
     {% trans "View more collaborations..." %}
   </a>
   <div>&nbsp;</div>
-</div>
+</body>

--- a/colab/super_archives/templates/widgets/dashboard_latest_threads.html
+++ b/colab/super_archives/templates/widgets/dashboard_latest_threads.html
@@ -1,6 +1,9 @@
 {% load i18n %}
 
-<div class="col-lg-6 col-md-6">
+<head>
+</head>
+
+<body>
   <h3 class="column-align">
     {% trans "Latest Threads" %}
   </h3>
@@ -17,4 +20,4 @@
     {% trans "View more discussions..." %}
   </a>
   <div>&nbsp;</div>
-</div>
+</body>

--- a/colab/super_archives/templates/widgets/dashboard_most_relevant_threads.html
+++ b/colab/super_archives/templates/widgets/dashboard_most_relevant_threads.html
@@ -1,6 +1,9 @@
 {% load i18n %}
 
-<div class="col-lg-6 col-md-6">
+<head>
+</head>
+
+<body>
   <h3 class="column-align">
     {% trans "Most Relevant Threads" %}
   </h3>
@@ -17,4 +20,4 @@
     {% trans "View more discussions..." %}
   </a>
   <div>&nbsp;</div>
-</div>
+</body>

--- a/colab/widgets/tests/test_widget_manager.py
+++ b/colab/widgets/tests/test_widget_manager.py
@@ -74,10 +74,10 @@ class WidgetManagerTest(TestCase):
         widget.content = "<head> Teste <head>"
         self.assertEqual(widget.get_header(), '')
 
-    def test_get_body_wrong(self):
+    def test_get_without_body(self):
         widget = self.default_widget_instance()
-        widget.content = "<body> Teste <body>"
-        self.assertEqual(widget.get_body(), '')
+        widget.content = "Teste"
+        self.assertEqual(widget.get_body(), widget.content)
 
     def test_generate_content(self):
         widgets = WidgetManager.get_widgets(self.widget_area)

--- a/colab/widgets/widget_manager.py
+++ b/colab/widgets/widget_manager.py
@@ -14,7 +14,7 @@ class Widget(object):
         end = self.content.find('</body>')
 
         if -1 in [start, end]:
-            return ''
+            return self.content
 
         body = self.content[start + len('<body>'):end]
         return mark_safe(body)


### PR DESCRIPTION
Now if the html template has no body tag, it will assumes that the html is only the content and returns it to get_body.