### PR TITLE
Fix translation infrastructure not ready in tests

### DIFF
--- a/colab/accounts/utils/mailman.py
+++ b/colab/accounts/utils/mailman.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.core import mail
 from django.template import Context, loader
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth import get_user_model
 
 TIMEOUT = 1


### PR DESCRIPTION
This fixes spb-plugin test breaking with: 
`
"The translation infrastructure cannot be initialized before the "
django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.
`