### PR TITLE
Add pagination to mail list view

### DIFF
--- a/colab/accounts/templates/accounts/manage_subscriptions.html
+++ b/colab/accounts/templates/accounts/manage_subscriptions.html
@@ -26,11 +26,29 @@
               </div>
             {% endfor %}
           </div>
+          <div class="panel-footer text-center">
+            <span class="step-links">
+              {% if lists.has_previous %}
+                  <a href="?page=1&per_page={{ per_page }}"><span class="glyphicon glyphicon-backward"></span></a>
+
+                  <a href="?page={{ lists.previous_page_number }}&per_page={{ per_page }}"><span class="glyphicon glyphicon-chevron-left"></span></a>
+              {% endif %}
+
+              <span class="current">
+                  {% trans 'Page' %} {{ lists.number }} {% trans 'of' %} {{ lists.paginator.num_pages }}.
+              </span>
+
+              {% if lists.has_next %}
+                  <a href="?page={{ lists.next_page_number }}&per_page={{ per_page }}"><span class="glyphicon glyphicon-chevron-right"></span></a>
+
+                  <a href="?page={{ lists.paginator.num_pages }}&per_page={{ per_page }}"><span class="glyphicon glyphicon-forward"></span></a>
+              {% endif %}
+            </span>
+          </div>
         </div>
       </div>
       {% endfor %}
-    </div>
-
+    </div>   
     <div class="row">
       <div class="text-center">
         <button class="btn btn-lg btn-primary" type="submit">{% trans 'Update subscriptions' %}</button>

--- a/colab/locale/pt_BR/LC_MESSAGES/django.po
+++ b/colab/locale/pt_BR/LC_MESSAGES/django.po
@@ -747,3 +747,9 @@ msgstr "Discussão"
 
 msgid "at"
 msgstr "às"
+
+msgid "Page"
+msgstr "Página"
+
+msgid "of"
+msgstr "de"


### PR DESCRIPTION
Adding pagination options to user mailing lists on 'manage_subscriptions.html' template and ordering the mailing lists alphabetically.

Signed-off-by: Emilie Morais <emilie.mo@hotmail.com>
Signed-off-by: Gabriel Silva <gabriel93.silva@gmail.com>
Signed-off-by: Italo Paiva <italosensei@hotmail.com>
Signed-off-by: Matheus Silva <matheussilva.fga@gmail.com>